### PR TITLE
Feat: 회원 특정 에셋에 대한 퀴즈 이력 조회

### DIFF
--- a/src/main/java/com/example/smakersbe/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/smakersbe/quiz/controller/QuizController.java
@@ -6,14 +6,12 @@ import com.example.smakersbe.quiz.dto.request.QuizCreateRequestDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAiAnalysisResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizCreateResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAttemptResponseDTO;
+import com.example.smakersbe.quiz.dto.response.QuizHistoryResponseDTO;
 import com.example.smakersbe.quiz.service.QuizService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -48,6 +46,17 @@ public class QuizController {
         log.info("퀴즈 결과 ai 분석 요청 중");
 
         QuizAiAnalysisResponseDTO response = quizService.createQuizAiAnalyze(requestDTO);
+        return ResponseEntity.ok(response);
+    }
+
+    // 사용자의 특정에셋에 대한 퀴즈 이력 조회
+    @GetMapping("/my/history")
+    public ResponseEntity<List<QuizHistoryResponseDTO>> fetchMyQuizHistory(
+            @RequestParam("uuid") String uuid,
+            @RequestParam("assetId") Long assetId
+            ) {
+
+        List<QuizHistoryResponseDTO> response = quizService.fetchMyQuizHistory(uuid, assetId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/smakersbe/quiz/dto/response/QuizHistoryResponseDTO.java
+++ b/src/main/java/com/example/smakersbe/quiz/dto/response/QuizHistoryResponseDTO.java
@@ -1,0 +1,44 @@
+package com.example.smakersbe.quiz.dto.response;
+
+import com.example.smakersbe.quiz.entity.QuizAttempt;
+import com.example.smakersbe.quiz.entity.QuizResult;
+import com.example.smakersbe.quiz.entity.QuizUserAnswer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QuizHistoryResponseDTO {
+    private Long attemptId;
+    private String formattedDate;
+    private Long correctCount;
+    private Long totalCount;
+    private String aiReview;
+    private List<Long> wrongQuestionNumbers;
+    private Long quizSetId;
+
+
+    public static QuizHistoryResponseDTO from(QuizAttempt attempt, QuizResult result, List<QuizUserAnswer> wrongAnswers) {
+        // null 일 때 사용할 값
+        boolean hasResult = (result != null);
+
+        return QuizHistoryResponseDTO.builder()
+                .attemptId(attempt.getQuizAttemptId())
+                .quizSetId(attempt.getQuizSet().getQuizSetId())
+                .correctCount(hasResult ? result.getCorrectCount() : 0L)
+                .totalCount(hasResult ? result.getTotalCount() : 0L)
+                .formattedDate(attempt.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy MM/dd hh:mma", Locale.ENGLISH)))                .aiReview(hasResult ? result.getAiReview() : "현재 AI 분석 결과를 생성 중입니다.")
+                .wrongQuestionNumbers(wrongAnswers.stream()
+                        .map(answer -> answer.getQuizSetItem().getQuizSetItemId())
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/example/smakersbe/quiz/entity/QuizAttempt.java
+++ b/src/main/java/com/example/smakersbe/quiz/entity/QuizAttempt.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "quiz_attempts")
 @Data
@@ -19,6 +21,14 @@ public class QuizAttempt {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="quiz_attempt_id", nullable = false, updatable = false)
     private Long quizAttemptId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="quiz_set_id", nullable = false)

--- a/src/main/java/com/example/smakersbe/quiz/entity/QuizResult.java
+++ b/src/main/java/com/example/smakersbe/quiz/entity/QuizResult.java
@@ -33,6 +33,11 @@ public class QuizResult {
     @Column(name="created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
     @Column(name="ai_review", columnDefinition = "TEXT", nullable = false)
     private String aiReview;
 

--- a/src/main/java/com/example/smakersbe/quiz/entity/QuizUserAnswer.java
+++ b/src/main/java/com/example/smakersbe/quiz/entity/QuizUserAnswer.java
@@ -29,6 +29,11 @@ public class QuizUserAnswer {
     @Column(name="created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="quiz_set_item_id", nullable = false)
     private QuizSetItem quizSetItem;

--- a/src/main/java/com/example/smakersbe/quiz/repository/QuizAttemptRepository.java
+++ b/src/main/java/com/example/smakersbe/quiz/repository/QuizAttemptRepository.java
@@ -20,4 +20,12 @@ public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> 
 
     @Query("SELECT qa.quizSet.quizSetId FROM QuizAttempt qa WHERE qa.user = :user AND qa.quizSet.asset = :asset")
     List<Long> findQuizSetIdsByUserAndAsset(@Param("user") User user, @Param("asset") Asset asset);
+
+    @Query("SELECT qa FROM QuizAttempt qa " +
+            "JOIN qa.quizSet qs " +
+            "JOIN qs.asset a " +
+            "WHERE qa.user.uuid = :uuid AND a.assetId = :assetId " +
+            "ORDER BY qa.quizAttemptId DESC")
+    List<QuizAttempt> findAllByUuidAndAssetId(@Param("uuid") String uuid, @Param("assetId") Long assetId);
+
 }

--- a/src/main/java/com/example/smakersbe/quiz/repository/QuizUserAnswerRepository.java
+++ b/src/main/java/com/example/smakersbe/quiz/repository/QuizUserAnswerRepository.java
@@ -1,5 +1,6 @@
 package com.example.smakersbe.quiz.repository;
 
+import com.example.smakersbe.quiz.entity.QuizAttempt;
 import com.example.smakersbe.quiz.entity.QuizUserAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +17,8 @@ public interface QuizUserAnswerRepository extends JpaRepository<QuizUserAnswer, 
             "JOIN FETCH ua.quizSetItem " +
             "WHERE ua.quizAttempt.quizAttemptId = :attemptId AND ua.isCorrect = false")
     List<QuizUserAnswer> findWrongAnswersWithItemByAttemptId(@Param("attemptId") Long attemptId);
+
+    List<QuizUserAnswer> findAllByQuizAttempt(QuizAttempt quizAttempt);
+
+
 }

--- a/src/main/java/com/example/smakersbe/quiz/service/QuizService.java
+++ b/src/main/java/com/example/smakersbe/quiz/service/QuizService.java
@@ -6,6 +6,7 @@ import com.example.smakersbe.quiz.dto.request.QuizCreateRequestDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAiAnalysisResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAttemptResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizCreateResponseDTO;
+import com.example.smakersbe.quiz.dto.response.QuizHistoryResponseDTO;
 
 import java.util.List;
 
@@ -16,6 +17,9 @@ public interface QuizService {
     QuizAttemptResponseDTO createQuizAttempt(QuizAttemptRequestDTO requestDTO);
 
     QuizAiAnalysisResponseDTO createQuizAiAnalyze(QuizAiAnalysisRequestDTO requestDTO);
+
+    List<QuizHistoryResponseDTO> fetchMyQuizHistory(String uuid, Long assetId);
+
 
 
     }

--- a/src/main/java/com/example/smakersbe/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/example/smakersbe/quiz/service/QuizServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.smakersbe.quiz.dto.request.QuizCreateRequestDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAiAnalysisResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAttemptResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizCreateResponseDTO;
+import com.example.smakersbe.quiz.dto.response.QuizHistoryResponseDTO;
 import com.example.smakersbe.quiz.entity.*;
 import com.example.smakersbe.quiz.repository.*;
 import com.example.smakersbe.user.entity.User;
@@ -53,6 +54,7 @@ public class QuizServiceImpl implements QuizService {
         처음 시행하는 시험(퀴즈 세트)라면 -> quiz_set_id 값에 Null 전달
      */
     /* 퀴즈 생성 요청이 들어오면 -> 퀴즈 생성 중인 컬럼을 true로 변경 */
+    @Transactional
     public List<QuizCreateResponseDTO> createQuiz(QuizCreateRequestDTO requestDTO){
 
         User user = userRepository.findByUuid(requestDTO.getUuid()).orElseThrow();
@@ -156,7 +158,6 @@ public class QuizServiceImpl implements QuizService {
             QuizUserAnswer quizUserAnswer = QuizUserAnswer.builder()
                     .userChoice(answerDTO.getUserChoice())
                     .isCorrect(isCorrect)
-                    .createdAt(LocalDateTime.now())
                     .quizAttempt(quizAttempt).
                     quizSetItem(quizSetItem).build();
             userAnswers.add(quizUserAnswer);
@@ -169,7 +170,6 @@ public class QuizServiceImpl implements QuizService {
                 .score((correctCount * 100) / requestDTO.getAnswers().size())
                 .totalCount((long)requestDTO.getAnswers().size())
                 .correctCount(correctCount)
-                .createdAt(LocalDateTime.now())
                 .aiReview("AI 분석을 요청해주세요.")
                 .build();
         quizResultRepository.save(quizResult);
@@ -201,7 +201,7 @@ public class QuizServiceImpl implements QuizService {
 
         // 프롬프트
         String getAiAnswer = aiGenerateService.getAiAnswer(
-                "너는 시험 분석 및 조언 전문가. \n"+
+                "너는 시험 분석 및 조언 전문가.\n"+
                         "1. 말투: 친절한 선배나 멘토처럼 (~해요, ~입니다)\n"+
                         "구조: [총평], [핵심 오답 분석], [향후 학습 가이드] 세 부분으로 나눌 것.\n"+
                         "분석 포인트: 유저가 선택한 오답과 정답을 비교하여 오개념을 정확히 짚어줄 것.\n"+
@@ -221,6 +221,26 @@ public class QuizServiceImpl implements QuizService {
         return QuizAiAnalysisResponseDTO.from(quizResult);
 
     }
+
+    // 4. 특정 에셋에 대한 사용자의 퀴즈 히스토리 조회
+    public List<QuizHistoryResponseDTO> fetchMyQuizHistory(String uuid, Long assetId){
+        List<QuizAttempt> quizAttempts = quizAttemptRepository.findAllByUuidAndAssetId(uuid, assetId);
+
+        return quizAttempts.stream()
+                .map(attempt -> {
+                    QuizResult result = quizResultRepository.findByQuizAttempt(attempt).orElse(null);
+
+                    List<QuizUserAnswer> allAnswers = quizUserAnswerRepository.findAllByQuizAttempt(attempt);
+                    List<QuizUserAnswer> wrongAnswers = allAnswers.stream() //전체 데이터 중
+                            .filter(answer -> !answer.getIsCorrect()) // 틀린 것만 필터링
+                            .toList();
+
+                    return QuizHistoryResponseDTO.from(attempt, result, wrongAnswers);
+                })
+                .toList();
+
+    }
+
 
 
     // options 파싱을 위한 메서드


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #26 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
- 회원 특정 에셋에 대한 퀴즈 이력 조회할 수 있도록 기능 구현 
- 회원은 모든 퀴즈세트에 대한 이력을 조회할 수 있다. 
- (만약 동일 시험지를 여러번 풀면 이에 대해서도 모든 기록 확인 가능함)


## ✅ 체크 리스트
- [ㅇ] develop 브랜치를 pull 완료했는가?
- [ㅇ] Merge 하려는 브랜치가 올바른가? 
- [ㅇ] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
