### PR TITLE
Feat:유저가 학습한 에셋에 대해서만 퀴즈 썸네일리스트 반환 기능 구현

### DIFF
--- a/src/main/java/com/example/smakersbe/asset/entity/Asset.java
+++ b/src/main/java/com/example/smakersbe/asset/entity/Asset.java
@@ -29,7 +29,7 @@ public class Asset {
     private String assetThumbnailUrl;
 
     // 퀴즈 생성 여부
-    @Column(nullable = false)
+    @Column(name="is_quiz_creating",nullable = false)
     private boolean isQuizCreating = false;
     // 퀴즈 생성하면 true -> false 로 상태 바꾸기
     public void updateQuizCreatingStatus(boolean status) {

--- a/src/main/java/com/example/smakersbe/asset/repository/UserAssetRepository.java
+++ b/src/main/java/com/example/smakersbe/asset/repository/UserAssetRepository.java
@@ -21,4 +21,16 @@ public interface UserAssetRepository extends JpaRepository<UserAsset, Long> {
     """)
     List<UserAsset> findAllByUserIdFetchAsset(@Param("userId") Long userId);
 
+    @Query("""
+    select ua
+    from UserAsset ua
+    join fetch ua.asset a
+    where ua.user.uuid = :uuid
+""")
+    List<UserAsset> findAllByUserUuidFetchAsset(@Param("uuid") String uuid);
+
+
+
+
+
 }

--- a/src/main/java/com/example/smakersbe/quiz/controller/QuizController.java
+++ b/src/main/java/com/example/smakersbe/quiz/controller/QuizController.java
@@ -3,6 +3,7 @@ package com.example.smakersbe.quiz.controller;
 import com.example.smakersbe.quiz.dto.request.QuizAiAnalysisRequestDTO;
 import com.example.smakersbe.quiz.dto.request.QuizAttemptRequestDTO;
 import com.example.smakersbe.quiz.dto.request.QuizCreateRequestDTO;
+import com.example.smakersbe.quiz.dto.response.QuizzableAssetListResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAiAnalysisResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizCreateResponseDTO;
 import com.example.smakersbe.quiz.dto.response.QuizAttemptResponseDTO;
@@ -58,6 +59,16 @@ public class QuizController {
 
         List<QuizHistoryResponseDTO> response = quizService.fetchMyQuizHistory(uuid, assetId);
         return ResponseEntity.ok(response);
+    }
+
+    // 사용자가 학습했던 에셋에 대한 퀴즈 썸네일 반환
+    @GetMapping("/my/quizzable-assets")
+    public ResponseEntity<List<QuizzableAssetListResponseDTO>> fetchMyQuizzableAssets(
+            @RequestParam("uuid") String uuid
+    ){
+        List<QuizzableAssetListResponseDTO> response = quizService.fetchMyQuizzableAssets(uuid);
+        return ResponseEntity.ok(response);
+
     }
 
 

--- a/src/main/java/com/example/smakersbe/quiz/dto/response/QuizzableAssetListResponseDTO.java
+++ b/src/main/java/com/example/smakersbe/quiz/dto/response/QuizzableAssetListResponseDTO.java
@@ -1,0 +1,16 @@
+package com.example.smakersbe.quiz.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QuizzableAssetListResponseDTO {
+    private String assetId;
+    private String assetName;
+    private String assetThumbnailUrl;
+}

--- a/src/main/java/com/example/smakersbe/quiz/service/QuizService.java
+++ b/src/main/java/com/example/smakersbe/quiz/service/QuizService.java
@@ -3,10 +3,7 @@ package com.example.smakersbe.quiz.service;
 import com.example.smakersbe.quiz.dto.request.QuizAiAnalysisRequestDTO;
 import com.example.smakersbe.quiz.dto.request.QuizAttemptRequestDTO;
 import com.example.smakersbe.quiz.dto.request.QuizCreateRequestDTO;
-import com.example.smakersbe.quiz.dto.response.QuizAiAnalysisResponseDTO;
-import com.example.smakersbe.quiz.dto.response.QuizAttemptResponseDTO;
-import com.example.smakersbe.quiz.dto.response.QuizCreateResponseDTO;
-import com.example.smakersbe.quiz.dto.response.QuizHistoryResponseDTO;
+import com.example.smakersbe.quiz.dto.response.*;
 
 import java.util.List;
 
@@ -19,6 +16,9 @@ public interface QuizService {
     QuizAiAnalysisResponseDTO createQuizAiAnalyze(QuizAiAnalysisRequestDTO requestDTO);
 
     List<QuizHistoryResponseDTO> fetchMyQuizHistory(String uuid, Long assetId);
+
+    List<QuizzableAssetListResponseDTO> fetchMyQuizzableAssets(String uuid);
+
 
 
 

--- a/src/main/java/com/example/smakersbe/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/example/smakersbe/quiz/service/QuizServiceImpl.java
@@ -3,15 +3,14 @@ package com.example.smakersbe.quiz.service;
 import com.example.smakersbe.ai.service.AiGenerateService;
 import com.example.smakersbe.asset.entity.Asset;
 import com.example.smakersbe.asset.entity.Memo;
+import com.example.smakersbe.asset.entity.UserAsset;
 import com.example.smakersbe.asset.repository.AssetRepository;
+import com.example.smakersbe.asset.repository.UserAssetRepository;
 import com.example.smakersbe.quiz.dto.request.QuizAiAnalysisRequestDTO;
 import com.example.smakersbe.quiz.dto.request.QuizAttemptRequestDTO;
 import com.example.smakersbe.quiz.dto.request.QuizCreateByAiRequestDTO;
 import com.example.smakersbe.quiz.dto.request.QuizCreateRequestDTO;
-import com.example.smakersbe.quiz.dto.response.QuizAiAnalysisResponseDTO;
-import com.example.smakersbe.quiz.dto.response.QuizAttemptResponseDTO;
-import com.example.smakersbe.quiz.dto.response.QuizCreateResponseDTO;
-import com.example.smakersbe.quiz.dto.response.QuizHistoryResponseDTO;
+import com.example.smakersbe.quiz.dto.response.*;
 import com.example.smakersbe.quiz.entity.*;
 import com.example.smakersbe.quiz.repository.*;
 import com.example.smakersbe.user.entity.User;
@@ -48,6 +47,7 @@ public class QuizServiceImpl implements QuizService {
     private final MemoRepository memoRepository;
     private final QuizUserAnswerRepository quizUserAnswerRepository;
     private final QuizResultRepository quizResultRepository;
+    private final UserAssetRepository userAssetRepository;
 
     // 1. 퀴즈 생성 요청 서비스
     /* 사용자가 만약 풀었던 시험를 다시 풀고싶다면 -> quiz_set_id 값 함께 전달
@@ -176,7 +176,6 @@ public class QuizServiceImpl implements QuizService {
 
         // response
         return QuizAttemptResponseDTO.from(quizAttempt, userAnswers, quizResult);
-
     }
 
     // 3. quiz 에 대한 ai 분석 요청
@@ -219,7 +218,6 @@ public class QuizServiceImpl implements QuizService {
 
         log.info("성공적으로 AI 리뷰가 저장되었습니다. 받아온 답변: {}, Attempt ID: {}", getAiAnswer,attempt.getQuizAttemptId());
         return QuizAiAnalysisResponseDTO.from(quizResult);
-
     }
 
     // 4. 특정 에셋에 대한 사용자의 퀴즈 히스토리 조회
@@ -238,10 +236,21 @@ public class QuizServiceImpl implements QuizService {
                     return QuizHistoryResponseDTO.from(attempt, result, wrongAnswers);
                 })
                 .toList();
-
     }
 
+    // 5. 사용자가 학습했던 에셋에 대해서만 퀴즈 썸네일 반환
+    // userAsset 테이블에 있는 assetId을 가지고 -> asset의 assetName, assetThumbnailUrl 반환
+    public List<QuizzableAssetListResponseDTO> fetchMyQuizzableAssets(String uuid){
+        List<UserAsset> assets = userAssetRepository.findAllByUserUuidFetchAsset(uuid);
 
+        return assets.stream()
+                .map(ua -> QuizzableAssetListResponseDTO.builder()
+                        .assetId(String.valueOf(ua.getAsset().getAssetId()))
+                        .assetName(ua.getAsset().getAssetName())
+                        .assetThumbnailUrl(ua.getAsset().getAssetThumbnailUrl())
+                        .build())
+                .toList();
+    }
 
     // options 파싱을 위한 메서드
     private List<String> parseOptions(String optionsJson) {
@@ -329,7 +338,5 @@ public class QuizServiceImpl implements QuizService {
                         .build())
                 .collect(Collectors.toList());
     }
-
-
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #28 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
- 회원이 자신이 학습한 에셋에 대해 퀴즈를 풀 수 있도록 퀴즈 썸네일 리스트 구현
- 에셋에 있는 썸네일 url을 가지고 구현

## 📸 UI 작업 시
<!-- 이미지 or 영상 첨부 -->

## ✅ 체크 리스트
- [ㅇ] develop 브랜치를 pull 완료했는가?
- [ㅇ] Merge 하려는 브랜치가 올바른가? 
- [ㅇ] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
